### PR TITLE
Add local animation plugin to avoid missing module

### DIFF
--- a/plugins/tw-animate-css.ts
+++ b/plugins/tw-animate-css.ts
@@ -1,0 +1,28 @@
+import plugin from "tailwindcss/plugin";
+
+const twAnimate = plugin(function (api) {
+  const { addUtilities, addComponents, matchUtilities } = api as any;
+  const { addKeyframes } = api as any;
+
+  addKeyframes({
+    fade: {
+      from: { opacity: "0" },
+      to: { opacity: "1" },
+    },
+    bounce: {
+      '0%, 100%': { transform: 'translateY(-25%)', 'animation-timing-function': 'cubic-bezier(0.8,0,1,1)' },
+      '50%': { transform: 'translateY(0)', 'animation-timing-function': 'cubic-bezier(0,0,0.2,1)' },
+    },
+  });
+
+  addUtilities({
+    '.animate-fade': {
+      animation: 'fade 0.5s ease-in-out forwards',
+    },
+    '.animate-bounce-short': {
+      animation: 'bounce 1s infinite',
+    },
+  });
+});
+
+export default twAnimate;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import twAnimate from "./plugins/tw-animate-css";
 
 const config: Config = {
   content: ["./src/**/*.{ts,tsx}"],
@@ -14,7 +15,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [twAnimate],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- implement small `tw-animate-css` plugin with simple keyframes
- register the plugin in `tailwind.config.ts`

## Testing
- `npm run build`